### PR TITLE
soapysdr, pothospython: rename python to python2

### DIFF
--- a/pothospython.rb
+++ b/pothospython.rb
@@ -9,7 +9,7 @@ class Pothospython < Formula
   depends_on "pothos"
   depends_on "poco"
   depends_on "nlohmann/json/nlohmann_json"
-  depends_on "python" => :recommended
+  depends_on "python2" => :recommended
   depends_on "python3" => :optional
 
   def install

--- a/soapysdr.rb
+++ b/soapysdr.rb
@@ -7,7 +7,7 @@ class Soapysdr < Formula
 
   depends_on "cmake" => :build
   depends_on "swig" => :build
-  depends_on "python" => :recommended
+  depends_on "python2" => :recommended
   depends_on "python3" => :optional
 
   def install


### PR DESCRIPTION
Homebrew has changed the `python` [formula](https://github.com/Homebrew/homebrew-core/blob/master/Formula/python.rb) to point to Python3 after python has declared to stop python2 support in the future. So `depends_on "python" => :recommended` is actually `depends_on "python3" => :recommended` now.

This PR points python to the python2 formula, which make these two recipes to build.

As a follow up to https://github.com/pothosware/homebrew-pothos/pull/7.