### PR TITLE
Make Python3 the default version and fix Python2 enablement

### DIFF
--- a/pothospython.rb
+++ b/pothospython.rb
@@ -10,7 +10,7 @@ class Pothospython < Formula
   depends_on "poco"
   depends_on "nlohmann/json/nlohmann_json"
   depends_on "python2" => :optional
-  depends_on "python3" => :recommended
+  depends_on "python" => :recommended
 
   def install
 
@@ -20,10 +20,10 @@ class Pothospython < Formula
 
     #using --with-python3 to build bindings for python3
     #its always one or the other, we cant build for both
-    if build.with?("python3")
-      args += ["-DPython_ADDITIONAL_VERSIONS=3"]
-    else
+    if build.with?("python2")
       args += ["-DPython_ADDITIONAL_VERSIONS=2"]
+    else
+      args += ["-DPython_ADDITIONAL_VERSIONS=3"]
     end
 
     mkdir "build" do

--- a/soapysdr.rb
+++ b/soapysdr.rb
@@ -8,20 +8,20 @@ class Soapysdr < Formula
   depends_on "cmake" => :build
   depends_on "swig" => :build
   depends_on "python2" => :optional
-  depends_on "python3" => :recommended
+  depends_on "python" => :recommended
 
   def install
 
     args = []
 
-    if build.with?("python")
+    if build.with?("python2")
         args += ["-DENABLE_PYTHON=ON"]
         args += ["-DUSE_PYTHON_CONFIG=ON"]
     else
         args += ["-DENABLE_PYTHON=OFF"]
     end
 
-    if build.with?("python3")
+    if build.with?("python")
       args += ["-DENABLE_PYTHON3=ON"]
     else
       args += ["-DENABLE_PYTHON3=OFF"]


### PR DESCRIPTION
As requested with enhancement #28

* resolves https://github.com/pothosware/homebrew-pothos/issues/28