### PR TITLE
revision bump due to poco upgrade

### DIFF
--- a/pothos.rb
+++ b/pothos.rb
@@ -1,6 +1,7 @@
 class Pothos < Formula
   desc "Pothos data-flow software suite"
   homepage "https://github.com/pothosware/PothosCore/wiki"
+  revision 1
   head "https://github.com/pothosware/PothosCore.git"
   url "https://github.com/pothosware/PothosCore/archive/pothos-0.7.1.tar.gz"
   sha256 "fc589209b6591068827a69add3c5d0493fe368debc929c7446eef2bac844e8c1"

--- a/pothosaudio.rb
+++ b/pothosaudio.rb
@@ -1,6 +1,7 @@
 class Pothosaudio < Formula
   desc "Pothos audio source and sink blocks"
   homepage "https://github.com/pothosware/PothosAudio/wiki"
+  revision 1
   head "https://github.com/pothosware/PothosAudio.git"
   url "https://github.com/pothosware/PothosAudio/archive/pothos-audio-0.3.1.tar.gz"
   sha256 "aa36aaa1116515e4634fa29d585df2b847f2238d3c4eb29375bb4a82de9a7d4a"

--- a/pothosblocks.rb
+++ b/pothosblocks.rb
@@ -1,6 +1,7 @@
 class Pothosblocks < Formula
   desc "Pothos core processing blocks"
   homepage "https://github.com/pothosware/PothosBlocks/wiki"
+  revision 1
   head "https://github.com/pothosware/PothosBlocks.git"
   url "https://github.com/pothosware/PothosBlocks/archive/pothos-blocks-0.5.3.tar.gz"
   sha256 "426338f7e398353ac074ea762a5962a2a699370bc812700e635de2170dd574e7"

--- a/pothoscomms.rb
+++ b/pothoscomms.rb
@@ -1,6 +1,7 @@
 class Pothoscomms < Formula
   desc "Pothos communications blocks"
   homepage "https://github.com/pothosware/PothosComms/wiki"
+  revision 1
   head "https://github.com/pothosware/PothosComms.git"
   url "https://github.com/pothosware/PothosComms/archive/pothos-comms-0.3.5.tar.gz"
   sha256 "d9e7524eb668350209b45c1a195a3427d86362974d600ecfe5625596ddb775e4"

--- a/pothosflow.rb
+++ b/pothosflow.rb
@@ -1,6 +1,7 @@
 class Pothosflow < Formula
   desc "Pothos graphical design tool"
   homepage "https://github.com/pothosware/PothosFlow/wiki"
+  revision 1
   head "https://github.com/pothosware/PothosFlow.git"
   url "https://github.com/pothosware/PothosFlow/archive/pothos-flow-0.7.1.tar.gz"
   sha256 "fa3b130f8b9164f7f26bee645cc80f490dfda47bd5efe5242c5f5f3b1c202f87"

--- a/pothospython.rb
+++ b/pothospython.rb
@@ -1,6 +1,7 @@
 class Pothospython < Formula
   desc "Pothos language bindings for Python"
   homepage "https://github.com/pothosware/PothosPython/wiki"
+  revision 1
   head "https://github.com/pothosware/PothosPython.git"
   url "https://github.com/pothosware/PothosPython/archive/pothos-python-0.4.3.tar.gz"
   sha256 "6086a9988ac86cc1ca96e2082aff426311ad941ad6a7d4d73eef07f9258920ad"

--- a/pothossoapy.rb
+++ b/pothossoapy.rb
@@ -1,6 +1,7 @@
 class Pothossoapy < Formula
   desc "Pothos SDR source and sink blocks"
   homepage "https://github.com/pothosware/PothosSoapy/wiki"
+  revision 1
   head "https://github.com/pothosware/PothosSoapy.git"
   url "https://github.com/pothosware/PothosSoapy/archive/pothos-soapy-0.5.1.tar.gz"
   sha256 "4dae46fe1763d9c32fc5706e65318166de389d9b946420297f00b7df55c052bc"


### PR DESCRIPTION
Fixes #23 a bit more generally.

Did
```
brew bump-revision -m "due to poco upgrade" $(brew uses poco)
```
and then something like
```
cd /usr/local/Homebrew/Library/Taps/pothosware/homebrew-pothos
git reset origin/master
git add .
git commit -m "revision bump due to poco upgrade"
```
to squash the commits into one.

Beware that `brew bump-revision` commits the changes into the current branch immediately. No idea what happens with changes that are already present.
Also, for now `brew uses poco` only lists formulae in the `pothosware/homebrew-pothos` tap, but it will need tweaking if/when other formulae become dependent on `poco`.
Might be good to check with `brew bump-revision -n  $(brew uses poco)` first as well.