### PR TITLE
Fix rpath on arm64

### DIFF
--- a/limesuite.rb
+++ b/limesuite.rb
@@ -48,6 +48,7 @@ class Limesuite < Formula
     end
 
     args += %W[-DLIME_SUITE_ROOT='#{HOMEBREW_PREFIX}']
+    args += ["-DCMAKE_INSTALL_NAME_DIR=#{lib}"]
 
     mkdir "builddir" do
       args += std_cmake_args


### PR DESCRIPTION
on arm64 (M1) cmake was not correctly replacing @rpath at link time
resulting in a runtime linker failure. This sets INSTALL_NAME_DIR
to the library path so that the default MACOSX_RPATH is not used.