### PR TITLE
Remove optional dependence on python2 formula

### DIFF
--- a/pothospython.rb
+++ b/pothospython.rb
@@ -9,7 +9,6 @@ class Pothospython < Formula
   depends_on "pothos"
   depends_on "poco"
   depends_on "nlohmann/json/nlohmann_json"
-  depends_on "python2" => :optional
   depends_on "python" => :recommended
 
   def install
@@ -17,14 +16,7 @@ class Pothospython < Formula
     args = []
 
     args += ["-DUSE_PYTHON_CONFIG=ON"]
-
-    #using --with-python3 to build bindings for python3
-    #its always one or the other, we cant build for both
-    if build.with?("python2")
-      args += ["-DPython_ADDITIONAL_VERSIONS=2"]
-    else
-      args += ["-DPython_ADDITIONAL_VERSIONS=3"]
-    end
+    args += ["-DPython_ADDITIONAL_VERSIONS=3"]
 
     mkdir "build" do
       args += std_cmake_args

--- a/soapysdr.rb
+++ b/soapysdr.rb
@@ -7,19 +7,11 @@ class Soapysdr < Formula
 
   depends_on "cmake" => :build
   depends_on "swig" => :build
-  depends_on "python2" => :optional
   depends_on "python" => :recommended
 
   def install
 
-    args = []
-
-    if build.with?("python2")
-        args += ["-DENABLE_PYTHON=ON"]
-        args += ["-DUSE_PYTHON_CONFIG=ON"]
-    else
-        args += ["-DENABLE_PYTHON=OFF"]
-    end
+    args = ["-DENABLE_PYTHON=OFF"]
 
     if build.with?("python")
       args += ["-DENABLE_PYTHON3=ON"]


### PR DESCRIPTION
The python2 formula no longer exists and having a reference to it prevents Homebrew from working. I encountered this issue [here](https://github.com/Homebrew/discussions/discussions/2635).