### PR TITLE
Update Lime Suite from v20.10.0 to v23.10.0.

### DIFF
--- a/limesuite.rb
+++ b/limesuite.rb
@@ -2,8 +2,8 @@ class Limesuite < Formula
   desc "Lime suite device drivers, GUI, and SDR support"
   homepage "https://github.com/myriadrf/LimeSuite/blob/master/README.md"
   head "https://github.com/myriadrf/LimeSuite.git"
-  url "https://github.com/myriadrf/LimeSuite/archive/v20.10.0.tar.gz"
-  sha256 "f6d79dc67cb52a5aea839d1dc00e65f85367cb2c275d77f149833d32cf79b467"
+  url "https://github.com/myriadrf/LimeSuite/archive/v23.10.0.tar.gz"
+  sha256 "3fcbc4a777e61c92d185e09f15c251e52c694f13ff3df110badc4ed36dc58b00"
 
   depends_on "cmake" => :build
   depends_on "sqlite" #core library dependency


### PR DESCRIPTION
v22.09.0 and later [adds support](https://github.com/myriadrf/LimeSuite/blob/v23.10.0/Changelog.txt) for LimeSDR Mini 2.0.